### PR TITLE
Added local lighthouse command

### DIFF
--- a/lighthouserc.local.json
+++ b/lighthouserc.local.json
@@ -2,7 +2,9 @@
   "ci": {
     "collect": {
       "numberOfRuns": 3,
-      "url": ["https://uat.idem.com.au"],
+      "startServerCommand": "yarn serve",
+      "startServerReadyPattern": "Local:",
+      "url": ["http://localhost:3000"],
       "isSinglePageApplication": true,
       "settings": {
         "onlyCategories": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write './'",
     "format-staged": "pretty-quick --staged",
     "postinstall": "husky install",
-    "test": "cross-env TS_NODE_PROJECT='./tsconfig.test.json' nyc --reporter=lcov mocha && yarn lighthouse:local",
+    "test": "cross-env TS_NODE_PROJECT='./tsconfig.test.json' nyc --reporter=lcov mocha",
     "lighthouse": "lhci autorun",
     "lighthouse:local": "lhci autorun --config=lighthouserc.local.json"
   },

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "format": "prettier --write './'",
     "format-staged": "pretty-quick --staged",
     "postinstall": "husky install",
-    "test": "cross-env TS_NODE_PROJECT='./tsconfig.test.json' nyc --reporter=lcov mocha",
+    "test": "cross-env TS_NODE_PROJECT='./tsconfig.test.json' nyc --reporter=lcov mocha && yarn lighthouse:local",
     "lighthouse": "lhci autorun",
-    "lighthouse:build": "yarn build && lhci autorun"
+    "lighthouse:local": "lhci autorun --config=lighthouserc.local.json"
   },
   "dependencies": {
     "axios": "^0.24.0",


### PR DESCRIPTION
Added some more lighthouse utility:
 - `yarn lighthouse` now tests `https://uat.idem.com.au`
 - `yarn lighthouse:local` now starts a local server and tests `http://localhost:3000` (requires Chrome installation)